### PR TITLE
포인트저장사용 동시성이슈 ReentrantLock 사용

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/application/LockProvider.kt
+++ b/src/main/kotlin/io/hhplus/tdd/application/LockProvider.kt
@@ -1,0 +1,15 @@
+package io.hhplus.tdd.application
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.jvm.internal.Ref.LongRef
+
+@Component
+class LockProvider {
+
+    private val lockMap: ConcurrentMap<Long, ReentrantLock> = ConcurrentHashMap()
+
+    fun getLock(key: Long): ReentrantLock = lockMap.computeIfAbsent(key) { ReentrantLock(true) }
+}


### PR DESCRIPTION
### 변경사항

* lock 을 가져오는 LockPorovider 작성
* 기존에는 Syncronized 를 사용하였지만 모든 유저가아닌 유저Id 별로 Lock 을 적용하고 싶어서 ReentrantRock 을 사용

### 리뷰 포인트
* 동시성 문제를 대응하는 방법으로 lock 을 사용하고 있는데, 이 부분에 대하여 리뷰 부탁드립니다.